### PR TITLE
UPD - WooCommerce cart validation page

### DIFF
--- a/easytransac_woocommerce.php
+++ b/easytransac_woocommerce.php
@@ -6,7 +6,7 @@ require __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autolo
  * Plugin Name: EasyTransac for WooCommerce
  * Plugin URI: https://www.easytransac.com
  * Description: Payment Gateway for EasyTransac. Create your account on <a href="https://www.easytransac.com">www.easytransac.com</a> to get your application key (API key) by following the steps on <a href="https://fr.wordpress.org/plugins/easytransac/installation/">the installation guide</a> and configure this plugin <a href="../wp-admin/admin.php?page=wc-settings&tab=checkout&section=easytransacgateway">here.</a> <strong>EasyTransac need Woocomerce.</strong>
- * Version: 2.8
+ * Version: 2.10
  *
  * Text Domain: easytransac_woocommerce
  * Domain Path: /i18n/languages/
@@ -559,7 +559,8 @@ function init_easytransac_gateway() {
 		*/
 		public function get_icon() {
 			$icon_url = plugin_dir_url(__FILE__) . '/includes/icon.png';
-			$icon_html = sprintf( '<br><a href="%1$s" class="about_easytransac" onclick="javascript:window.open(\'%1$s\',\'WIEasyTransac\',\'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700\'); return false;">' . esc_attr__( 'What is EasyTransac?', 'easytransac_woocommerce' ) . '</a>', esc_url('https://www.easytransac.com/fr/support'));
+			$icon_html = "<script type=\"text/javascript\">function usingGateway(){console.log(jQuery(\"input[name='payment_method']:checked\").val()),\"easytransac\"==jQuery('form[name=\"checkout\"] input[name=\"payment_method\"]:checked').val()?document.getElementById(\"easytransac-icon\").style.visibility=\"visible\":document.getElementById(\"easytransac-icon\").style.visibility=\"hidden\"}jQuery(function(){jQuery(\"body\").on(\"updated_checkout\",function(){usingGateway(),jQuery('input[name=\"payment_method\"]').change(function(){console.log(\"payment method changed\"),usingGateway()})})});</script>";
+			$icon_html .= sprintf( '<br><a href="%1$s" class="about_easytransac" onclick="javascript:window.open(\'%1$s\',\'WIEasyTransac\',\'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700\'); return false;">' . esc_attr__( 'What is EasyTransac?', 'easytransac_woocommerce' ) . '</a>', esc_url('https://www.easytransac.com/fr/support'));
 			$icon_html .= '<img src="' . esc_attr($icon_url) . '" alt="' . esc_attr__('EasyTransac', 'easytransac_woocommerce') . '" style="max-height:52px;display:inline-block;margin-top:55px;" />';
 			// Injects OneClick if enabled.
 			$oneclick = $this->get_option('oneclick');


### PR DESCRIPTION
Update easytransac payment method in woocomerce cart validation page.
Removing the easytransac image when the payment checkbox is unchecked.

Before : https://drive.google.com/open?id=1DQhlH9EC3L89Z1kBOM-tfdWj_miCCDqS
After : https://drive.google.com/open?id=1ddhUH8ThTeIk7eAzWuM3_C6R3su3a4xV

Signed-off-by: Maxime Killinger <max.killinger@outlook.fr>

modifié :         easytransac_woocommerce.php